### PR TITLE
Sync: Add ClusterServiceLoadBalancerHealthProbeMode=Shared to AWS CCM config (sync-with-hcp-agent)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
@@ -6,6 +6,7 @@ data:
     VPC = %s
     KubernetesClusterID = %s
     SubnetID = %s
+    ClusterServiceLoadBalancerHealthProbeMode = Shared
 kind: ConfigMap
 metadata:
   name: aws-cloud-config


### PR DESCRIPTION
This PR syncs the AWS CCM config with upstream: adds ClusterServiceLoadBalancerHealthProbeMode=Shared to enable shared health checks for AWS load balancers, as per OCPCLOUD-2843 and https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/383.