### PR TITLE
aws ccm: Set ClusterServiceLoadBalancerHealthProbeMode=Shared by default (sync with OCPCLOUD-2843)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
@@ -6,6 +6,7 @@ data:
     VPC = %s
     KubernetesClusterID = %s
     SubnetID = %s
+    ClusterServiceLoadBalancerHealthProbeMode = Shared
 kind: ConfigMap
 metadata:
   name: aws-cloud-config


### PR DESCRIPTION
This PR syncs the AWS CCM config default for ClusterServiceLoadBalancerHealthProbeMode=Shared, matching the change in https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/383 (OCPCLOUD-2843). This ensures AWS load balancer health checks use the shared OVN kube-proxy endpoint by default, as required for OpenShift clusters. No other functional changes.