### PR TITLE
Add [Shared] section to AWS CCM config to disable security group ingress for health probes (sync with OCPCLOUD-2843)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
@@ -6,6 +6,9 @@ data:
     VPC = %s
     KubernetesClusterID = %s
     SubnetID = %s
+
+    [Shared]
+    DisableSecurityGroupIngress = true
 kind: ConfigMap
 metadata:
   name: aws-cloud-config


### PR DESCRIPTION
This PR syncs the AWS Cloud Controller Manager config with OCPCLOUD-2843 by adding a [Shared] section to disable security group ingress for health probes.\n\nLabel: created-by-hcp-agent