### PR TITLE
Enable MutatingAdmissionPolicy API in KAS when feature gate is set (sync with upstream registration)

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -239,6 +239,9 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 		if gate == "ValidatingAdmissionPolicy=true" {
 			runtimeConfig = append(runtimeConfig, "admissionregistration.k8s.io/v1beta1=true")
 		}
+		if gate == "MutatingAdmissionPolicy=true" {
+			runtimeConfig = append(runtimeConfig, "admissionregistration.k8s.io/v1alpha1=true")
+		}
 		if gate == "DynamicResourceAllocation=true" {
 			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1beta1=true")
 		}


### PR DESCRIPTION
This PR syncs with the upstream registration of the MutatingAdmissionPolicy feature gate. When the MutatingAdmissionPolicy feature gate is enabled, the KAS will now enable the corresponding API group (admissionregistration.k8s.io/v1alpha1) via runtime-config, mirroring the handling for ValidatingAdmissionPolicy.\n\nLabel: created-by-hcp-agent